### PR TITLE
"🎯 Fix: Use correct Firebase App ID in Fastlane release lane

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -8,7 +8,7 @@ platform :android do
     sh "flutter build apk --release --flavor production --target lib/main_production.dart --no-tree-shake-icons"
 
     firebase_app_distribution(
-      app: "1:754897613485:android:8cea1548a7dd94d6874c24",
+      app: "1:229377264955:android:8f3f3a1023e16bfd61fb1e",
       firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
       android_artifact_type: "APK",
       android_artifact_path: "../build/app/outputs/flutter-apk/app-production-release.apk",


### PR DESCRIPTION
Updated the Firebase App ID in Fastfile to match the correct Firebase project (com.example.note_flow). The issue occurred due to copying the App ID from another app by mistake. Verified that the package name and Firebase configuration now match correctly for deployment."